### PR TITLE
Add missing method to javascript client

### DIFF
--- a/src/ondemand-client.js
+++ b/src/ondemand-client.js
@@ -242,6 +242,20 @@ var OnDemandClient = (function () {
         return _checkParamsAndFetch(requestData, options, callback);
     };
 
+    Constr.prototype.getETFDetails = function (options, callback) {
+        var requestData = {
+            url: _baseUrl + '/getETFDetails.' + _format()
+        };
+        return _checkParamsAndFetch(requestData, options, callback);
+    };
+
+    Constr.prototype.getSymbolLookup = function (options, callback) {
+        var requestData = {
+            url: _baseUrl + '/getSymbolLookUp.' + _format()
+        };
+        return _checkParamsAndFetch(requestData, options, callback);
+    };
+
     /*
      * FIXME: OnDemand will not return more than one source (feed)
      * */


### PR DESCRIPTION
Add missing methods from the documentation:
- http://www.barchartondemand.com/get/etfdetails.php
- http://barchartondemand.com/api/getSymbolLookUp
