### PR TITLE
The client now uses the HTTPS protocol instead of the old HTTP

### DIFF
--- a/src/ondemand-client.js
+++ b/src/ondemand-client.js
@@ -16,7 +16,7 @@ var OnDemandClient = (function () {
 
     'use strict';
 
-    var _baseUrl = 'http://ondemand.websol.barchart.com';
+    var _baseUrl = 'https://ondemand.websol.barchart.com';
     var _apiKey = null;
     var _promiseImplementation = null;
     var _useJsonP = true;


### PR DESCRIPTION
This change is required in order to avoid the browser to block the request if loaded in a secure HTTPS server.